### PR TITLE
[optitrack ahrs]

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -70,6 +70,7 @@ SRC+=./core/main.c \
 	./core/state_estimator/ahrs/comp_ahrs.c \
 	./core/state_estimator/ahrs/madgwick_ahrs.c \
 	./core/state_estimator/ahrs/eskf_ahrs.c \
+	./core/state_estimator/ahrs/optitrack_ahrs.c \
 	./core/state_estimator/ins/ins_comp_filter.c \
 	./core/state_estimator/ins/gps_to_enu.c \
 	./core/state_estimator/ins/ins.c \

--- a/src/core/state_estimator/ahrs/ahrs.c
+++ b/src/core/state_estimator/ahrs/ahrs.c
@@ -7,6 +7,7 @@
 #include "comp_ahrs.h"
 #include "madgwick_ahrs.h"
 #include "eskf_ahrs.h"
+#include "optitrack_ahrs.h"
 #include "lpf.h"
 #include "uart.h"
 #include "matrix.h"
@@ -45,6 +46,8 @@ void ahrs_init(void)
 	madgwick_init(&madgwick_ahrs, 400, 0.13);
 
 	eskf_ahrs_init(0.0025);
+	
+	optitrack_ahrs_init(0.0025);
 
 	switch(SELECT_HEADING_SENSOR) {
 	case HEADING_SENSOR_USE_COMPASS:
@@ -356,6 +359,8 @@ void ahrs_estimate(void)
 	}
 
 	get_eskf_attitude_quaternion(attitude.q);
+#elif (SELECT_AHRS == AHRS_OPTITRACK_FILTER)
+    ahrs_optitrack_complementary_filter_estimate(attitude.q, gyro_rad);
 #endif
 
 #if (SELECT_HEADING_SENSOR == HEADING_SENSOR_USE_OPTITRACK)

--- a/src/core/state_estimator/ahrs/optitrack_ahrs.c
+++ b/src/core/state_estimator/ahrs/optitrack_ahrs.c
@@ -1,0 +1,69 @@
+#include <math.h>
+#include <stdio.h>
+#include "arm_math.h"
+#include "ahrs.h"
+#include "optitrack_ahrs.h"
+#include "matrix.h"
+#include "quaternion.h"
+#include "optitrack.h"
+
+MAT_ALLOC(q, 4, 1);
+MAT_ALLOC(R_gyro, 3, 3);
+
+float optitrack_ahrs_dt = 0.0f;
+
+void optitrack_ahrs_init(float ahrs_dt)
+{
+	MAT_INIT(q, 4, 1);
+	MAT_INIT(R_gyro, 3, 3);
+
+	optitrack_ahrs_dt = ahrs_dt;
+
+	mat_data(q)[0] = 1.0f;
+	mat_data(q)[1] = 0.0f;
+	mat_data(q)[2] = 0.0f;
+	mat_data(q)[3] = 0.0f;
+}
+
+void ahrs_optitrack_complementary_filter_estimate(float *q_out, float *gyro)
+{
+	/* quaternion integration (with gyroscope) */
+	float w[4];
+	w[0] = 0.0f;
+	w[1] = gyro[0];
+	w[2] = gyro[1];
+	w[3] = gyro[2];
+
+	float q_dot[4];
+	quaternion_mult(w, mat_data(q), q_dot);
+
+	float q_gyro[4];
+	float half_dt = -0.5 * optitrack_ahrs_dt;
+	q_gyro[0] = mat_data(q)[0] + (q_dot[0] * half_dt);
+	q_gyro[1] = mat_data(q)[1] + (q_dot[1] * half_dt);
+	q_gyro[2] = mat_data(q)[2] + (q_dot[2] * half_dt);
+	q_gyro[3] = mat_data(q)[3] + (q_dot[3] * half_dt);
+	quat_normalize(q_gyro);
+//-----------------------------------------------------------------
+
+	//get_the_optitrack_quaternion_value_from_optitrack.c
+	float optitrack_q[4];
+	optitrack_read_q_0(&optitrack_q[0]);
+	optitrack_read_q_1(&optitrack_q[1]);
+	optitrack_read_q_2(&optitrack_q[2]);
+	optitrack_read_q_3(&optitrack_q[3]);
+
+	// select the final result (q_gyroscope or q_optitrack) 
+	if(optitrack_available() == true) {
+		q_out[0] = optitrack_q[0];
+		q_out[1] = optitrack_q[2];
+		q_out[2] = optitrack_q[1];
+		q_out[3] = optitrack_q[3];
+	} else {
+		q_out[0] = q_gyro[0];
+		q_out[1] = q_gyro[2];
+		q_out[2] = q_gyro[1];
+		q_out[3] = q_gyro[3];
+	}
+
+}

--- a/src/core/state_estimator/ahrs/optitrack_ahrs.h
+++ b/src/core/state_estimator/ahrs/optitrack_ahrs.h
@@ -1,0 +1,7 @@
+#ifndef __OPTITRACK_AHRS_H__
+#define __OPTITRACK_AHRS_H__
+
+void optitrack_ahrs_init(float ahrs_dt);
+void ahrs_optitrack_complementary_filter_estimate(float *q_out, float *gyro);
+
+#endif

--- a/src/drivers/device/optitrack.c
+++ b/src/drivers/device/optitrack.c
@@ -192,6 +192,26 @@ float optitrack_read_vel_z(void)
 	return optitrack.vel_raw[2];
 }
 
+void optitrack_read_q_0(float *q0)
+{
+	*q0 = optitrack.q[0];
+}
+
+void optitrack_read_q_1(float *q1)
+{
+	*q1 = optitrack.q[1];
+}
+
+void optitrack_read_q_2(float *q2)
+{
+	*q2 = optitrack.q[2];
+}
+
+void optitrack_read_q_3(float *q3)
+{
+	*q3 = optitrack.q[3];
+}
+
 void send_optitrack_position_debug_message(debug_msg_t *payload)
 {
 	float px = optitrack.pos[0] * 100.0f; //[cm]

--- a/src/drivers/device/optitrack.h
+++ b/src/drivers/device/optitrack.h
@@ -42,6 +42,10 @@ float optitrack_read_pos_z(void);
 float optitrack_read_vel_x(void);
 float optitrack_read_vel_y(void);
 float optitrack_read_vel_z(void);
+void optitrack_read_q_0(float *q0);
+void optitrack_read_q_1(float *q1);
+void optitrack_read_q_2(float *q2);
+void optitrack_read_q_3(float *q3);
 
 void send_optitrack_position_debug_message(debug_msg_t *payload);
 void send_optitrack_quaternion_debug_message(debug_msg_t *payload);

--- a/src/proj_config.h
+++ b/src/proj_config.h
@@ -26,7 +26,8 @@
 #define AHRS_COMPLEMENTARY_FILTER 0
 #define AHRS_MADGWICK_FILTER      1
 #define AHRS_ESKF                 2
-#define SELECT_AHRS AHRS_ESKF
+#define AHRS_OPTITRACK_FILTER     3 
+#define SELECT_AHRS AHRS_OPTITRACK_FILTER
 
 /* ins algorithms */
 #define INS_COMPLEMENTARY_FILTER 0


### PR DESCRIPTION
1. add two files: optitrack_ahrs.c and optitrack_ahrs.h
   to the path src/core/estimators/attitude/ for getting the
   attitude from optitrack and gyro.
2. revise
(1)Makefile: for compiling the file optitrack_ahrs.c.
(2)com_ahrs.c: recover to the normal version.
(3)ahrs.c: add the filter mode AHRS_OPTITRACK_FILTER.
(4)proj_config.h: select the new filter mode AHRS_OPTITRACK_FILTER.